### PR TITLE
chore(tests): Upgrade JUnit from v4 to v5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@
  *
  * This generated file contains a sample Kotlin library project to get you started.
  */
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 group = "tech.relaycorp"
 
@@ -38,8 +39,9 @@ dependencies {
     // Use the Kotlin test library.
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 
-    // Use the Kotlin JUnit integration.
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
+    // Use the Kotlin JUnit5 integration.
+    testImplementation("org.junit.jupiter:junit-jupiter:5.6.0")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 }
 
 java {
@@ -84,11 +86,19 @@ tasks.jacocoTestCoverageVerification {
 }
 
 tasks.test {
+    useJUnitPlatform()
+    testLogging {
+        events("passed", "skipped", "failed")
+    }
     finalizedBy("jacocoTestReport")
     doLast {
         println("View code coverage at:")
         println("file://$buildDir/reports/jacoco/test/html/index.html")
     }
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions.jvmTarget = "1.8"
 }
 
 tasks.dokka {


### PR DESCRIPTION
I checked this is indeed using v5 by breaking a test and finding references to JUnit5 in the stack trace.

These changes are based on the official Gradle Kotlin DSL example: https://github.com/junit-team/junit5-samples/blob/master/junit5-jupiter-starter-gradle-kotlin/build.gradle.kts

I'm still able to run tests from IntelliJ:
![junit5](https://user-images.githubusercontent.com/369863/75873773-6aa26b80-5e08-11ea-83e0-2a7a5883e143.gif)
