### PR TITLE
fix(RAMF): Exit early when deserializing large payloads

### DIFF
--- a/src/main/kotlin/tech/relaycorp/relaynet/ramf/RAMFSerializer.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/ramf/RAMFSerializer.kt
@@ -24,6 +24,8 @@ import org.bouncycastle.asn1.ASN1TaggedObject
 import org.bouncycastle.asn1.DEROctetString
 import org.bouncycastle.asn1.DERVisibleString
 
+private const val OCTETS_IN_9_MIB = 9437184
+
 private val DER_SEQUENCE_TAG = BerTag(BerTag.UNIVERSAL_CLASS, BerTag.CONSTRUCTED, 16)
 
 private val UTC_ZONE_ID: ZoneId = ZoneId.of("UTC")
@@ -83,7 +85,13 @@ internal open class RAMFSerializer<T : RAMFMessage>(
     @Throws(RAMFException::class)
     fun deserialize(serialization: ByteArray): T {
         val serializationStream = ByteArrayInputStream(serialization)
-        if (serializationStream.available() < 10) {
+        val serializationSize = serializationStream.available()
+
+        if (OCTETS_IN_9_MIB < serializationSize) {
+            throw RAMFException("Message should not be larger than 9 MiB")
+        }
+
+        if (serializationSize < 10) {
             throw RAMFException("Serialization is too short to contain format signature")
         }
 

--- a/src/test/kotlin/tech/relaycorp/relaynet/ramf/RAMFSerializerTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/ramf/RAMFSerializerTest.kt
@@ -159,6 +159,26 @@ class RAMFSerializerTest {
 
     @Nested
     inner class Deserialize {
+        private val octetsIn9Mib = 9437184
+
+        @Test
+        fun `Messages up to 9 MiB should be accepted`() {
+            val invalidSerialization = "a".repeat(octetsIn9Mib).toByteArray()
+
+            // Deserialization still fails, but for a different reason
+            val exception = assertThrows<RAMFException> { stubSerializer.deserialize(invalidSerialization) }
+            assertEquals("Format signature should start with magic constant 'Relaynet'", exception.message)
+        }
+
+        @Test
+        fun `Messages larger than 9 MiB should be refused`() {
+            val invalidSerialization = "a".repeat(octetsIn9Mib + 1).toByteArray()
+
+            val exception = assertThrows<RAMFException> { stubSerializer.deserialize(invalidSerialization) }
+
+            assertEquals("Message should not be larger than 9 MiB", exception.message)
+        }
+
         @Nested
         inner class FormatSignature {
             @Test


### PR DESCRIPTION
RAMF message fields shouldn't take more than just over 8 MiB [1], but I'm rounding up the maximum to 9 MiB to also account for the CMS SignedData wrapper, which will contain one or more X.509 certificates (not that they should take up 1 MiB collectively).

[1] https://github.com/relaynet/specs/pull/52
