### PR TITLE
fix: Release using JDK 8 to try workaround for Gradle issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,13 @@ jobs:
 
   release:
     needs: ci
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 8
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
https://discuss.gradle.org/t/cant-add-kotlin-jvm-library-as-dependency-to-another-kotlin-jvm-library-due-to-target-jdk-version/35971

If this works, it'd unblock: https://github.com/relaycorp/relaynet-cogrpc-jvm/pull/14