### PR TITLE
fix: Use correct concrete message type for CCAs

### DIFF
--- a/src/main/kotlin/tech/relaycorp/relaynet/messages/CargoCollectionAuthorization.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/messages/CargoCollectionAuthorization.kt
@@ -8,7 +8,7 @@ import tech.relaycorp.relaynet.wrappers.x509.Certificate
 import java.io.InputStream
 import java.time.ZonedDateTime
 
-private val SERIALIZER = RAMFSerializer(0x51, 0x00)
+private val SERIALIZER = RAMFSerializer(0x44, 0x00)
 
 class CargoCollectionAuthorization(
     recipientAddress: String,

--- a/src/test/kotlin/tech/relaycorp/relaynet/messages/CargoCollectionAuthorizationTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/messages/CargoCollectionAuthorizationTest.kt
@@ -12,7 +12,7 @@ class CargoCollectionAuthorizationTest {
         makeRAMFMessageConstructorTests(
             ::CargoCollectionAuthorization,
             { r: String, p: ByteArray, s: Certificate -> CargoCollectionAuthorization(r, p, s) },
-            0x51,
+            0x44,
             0x00
         )
 


### PR DESCRIPTION
This is blocking https://github.com/relaycorp/relaynet-courier-android/pull/54
