### PR TITLE
fix(Client registration): Use raw RSA signatures instead of shoehorning SignedData

### DIFF
--- a/src/main/kotlin/tech/relaycorp/relaynet/crypto/RSASigning.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/crypto/RSASigning.kt
@@ -1,0 +1,24 @@
+package tech.relaycorp.relaynet.crypto
+
+import tech.relaycorp.relaynet.BC_PROVIDER
+import java.security.PrivateKey
+import java.security.PublicKey
+import java.security.Signature
+
+internal object RSASigning {
+    fun sign(plaintext: ByteArray, privateKey: PrivateKey): ByteArray {
+        val signature = makeSignature()
+        signature.initSign(privateKey)
+        signature.update(plaintext)
+        return signature.sign()
+    }
+
+    fun verify(ciphertext: ByteArray, publicKey: PublicKey, expectedPlaintext: ByteArray): Boolean {
+        val signature = makeSignature()
+        signature.initVerify(publicKey)
+        signature.update(expectedPlaintext)
+        return signature.verify(ciphertext)
+    }
+
+    private fun makeSignature() = Signature.getInstance("SHA256withRSAandMGF1", BC_PROVIDER)
+}

--- a/src/test/kotlin/tech/relaycorp/relaynet/crypto/RSASigningTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/crypto/RSASigningTest.kt
@@ -1,0 +1,65 @@
+package tech.relaycorp.relaynet.crypto
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import tech.relaycorp.relaynet.BC_PROVIDER
+import tech.relaycorp.relaynet.wrappers.generateRSAKeyPair
+import java.security.Signature
+import java.security.spec.MGF1ParameterSpec
+import java.security.spec.PSSParameterSpec
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RSASigningTest {
+    private val plaintext = "the plaintext".toByteArray()
+    private val keyPair = generateRSAKeyPair()
+
+    @Nested
+    inner class Sign {
+        @Test
+        fun `The plaintext should be signed with RSA-PSS, SHA-256 and MGF1`() {
+            val ciphertext = RSASigning.sign(plaintext, keyPair.private)
+
+            val signature: Signature = makeSignature()
+            signature.initVerify(keyPair.public)
+            signature.update(plaintext)
+
+            assertTrue(signature.verify(ciphertext))
+        }
+    }
+
+    @Nested
+    inner class Verify {
+        @Test
+        fun `Invalid plaintexts should be refused`() {
+            val anotherPlaintext = byteArrayOf(*plaintext, 1)
+            val ciphertext = RSASigning.sign(anotherPlaintext, keyPair.private)
+
+            assertFalse(RSASigning.verify(ciphertext, keyPair.public, plaintext))
+        }
+
+        @Test
+        fun `Algorithms other than RSA-PSS with SHA-256 and MGF1 should be refused`() {
+            val signature: Signature = Signature.getInstance("SHA256withRSA", BC_PROVIDER)
+            signature.initSign(keyPair.private)
+            signature.update(plaintext)
+            val ciphertext = signature.sign()
+
+            assertFalse(RSASigning.verify(ciphertext, keyPair.public, plaintext))
+        }
+
+        @Test
+        fun `Valid signatures should be accepted`() {
+            val ciphertext = RSASigning.sign(plaintext, keyPair.private)
+
+            assertTrue(RSASigning.verify(ciphertext, keyPair.public, plaintext))
+        }
+    }
+
+    private fun makeSignature(): Signature {
+        val signature = Signature.getInstance("SHA256withRSA/PSS", BC_PROVIDER)
+        val pssParameterSpec = PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1)
+        signature.setParameter(pssParameterSpec)
+        return signature
+    }
+}

--- a/src/test/kotlin/tech/relaycorp/relaynet/messages/control/ClientRegistrationRequestTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/messages/control/ClientRegistrationRequestTest.kt
@@ -1,15 +1,12 @@
 package tech.relaycorp.relaynet.messages.control
 
-import org.bouncycastle.asn1.ASN1ObjectIdentifier
-import org.bouncycastle.asn1.ASN1TaggedObject
 import org.bouncycastle.asn1.DERNull
 import org.bouncycastle.asn1.DEROctetString
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import tech.relaycorp.relaynet.OIDs
-import tech.relaycorp.relaynet.crypto.SignedData
-import tech.relaycorp.relaynet.crypto.SignedDataException
+import tech.relaycorp.relaynet.crypto.RSASigning
 import tech.relaycorp.relaynet.messages.InvalidMessageException
 import tech.relaycorp.relaynet.wrappers.KeyException
 import tech.relaycorp.relaynet.wrappers.asn1.ASN1Exception
@@ -39,54 +36,34 @@ class ClientRegistrationRequestTest {
         }
 
         @Test
-        fun `CRA countersignature should be a valid SignedData value`() {
-            val request = ClientRegistrationRequest(keyPair.public, craSerialized)
-
-            val serialization = request.serialize(keyPair.private)
-
-            val sequence = ASN1Utils.deserializeSequence(serialization)
-            val craCountersignatureASN1 = sequence[1]
-            val craCountersignatureSerialized =
-                ASN1Utils.getOctetString(craCountersignatureASN1).octets
-            SignedData.deserialize(craCountersignatureSerialized)
-                .also { it.verify(signerPublicKey = keyPair.public) }
-        }
-
-        @Test
-        fun `CRA countersignature should be prefixed with correct OID`() {
-            val request = ClientRegistrationRequest(keyPair.public, craSerialized)
-
-            val serialization = request.serialize(keyPair.private)
-
-            val requestSequence = ASN1Utils.deserializeSequence(serialization)
-            val craCountersignatureASN1 = requestSequence[1]
-            val craCountersignature = ASN1Utils.getOctetString(craCountersignatureASN1)
-            val craSequence = extractSignedSequence(craCountersignature.octets)
-            assertEquals(
-                OIDs.CRA_COUNTERSIGNATURE,
-                ASN1Utils.getOID(craSequence.first())
-            )
-        }
-
-        @Test
         fun `CRA countersignature should contain correct CRA`() {
             val request = ClientRegistrationRequest(keyPair.public, craSerialized)
 
             val serialization = request.serialize(keyPair.private)
 
             val sequence = ASN1Utils.deserializeSequence(serialization)
-            val signedCRA = ASN1Utils.getOctetString(sequence[1])
-            val craSequence = extractSignedSequence(signedCRA.octets)
-            val authorizationASN1 = craSequence[1]
+            val craDeserialized = ASN1Utils.getOctetString(sequence[1]).octets
             assertEquals(
                 craSerialized.asList(),
-                ASN1Utils.getOctetString(authorizationASN1).octets.asList()
+                craDeserialized.asList()
             )
         }
 
-        private fun extractSignedSequence(serialization: ByteArray): Array<ASN1TaggedObject> {
-            val signedData = SignedData.deserialize(serialization)
-            return ASN1Utils.deserializeSequence(signedData.plaintext!!)
+        @Test
+        fun `CRA countersignature should be valid`() {
+            val request = ClientRegistrationRequest(keyPair.public, craSerialized)
+
+            val serialization = request.serialize(keyPair.private)
+
+            val sequence = ASN1Utils.deserializeSequence(serialization)
+            val craCountersignatureASN1 = sequence[2]
+            val craCountersignature =
+                ASN1Utils.getOctetString(craCountersignatureASN1).octets
+            val expectedPlaintext = ASN1Utils.serializeSequence(
+                arrayOf(OIDs.CRA_COUNTERSIGNATURE, DEROctetString(craSerialized)),
+                false
+            )
+            assertTrue(RSASigning.verify(craCountersignature, keyPair.public, expectedPlaintext))
         }
     }
 
@@ -105,14 +82,15 @@ class ClientRegistrationRequestTest {
         }
 
         @Test
-        fun `Sequence should have at least 2 items`() {
-            val serialization = ASN1Utils.serializeSequence(arrayOf(DERNull.INSTANCE), false)
+        fun `Sequence should have at least 3 items`() {
+            val serialization =
+                ASN1Utils.serializeSequence(arrayOf(DERNull.INSTANCE, DERNull.INSTANCE), false)
 
             val exception = assertThrows<InvalidMessageException> {
                 ClientRegistrationRequest.deserialize(serialization)
             }
 
-            assertEquals("CRR sequence should have at least 2 items (got 1)", exception.message)
+            assertEquals("CRR sequence should have at least 3 items (got 2)", exception.message)
         }
 
         @Test
@@ -120,6 +98,7 @@ class ClientRegistrationRequestTest {
             val serialization = ASN1Utils.serializeSequence(
                 arrayOf(
                     DEROctetString("foo".toByteArray()),
+                    DERNull.INSTANCE,
                     DERNull.INSTANCE
                 ),
                 false
@@ -133,140 +112,36 @@ class ClientRegistrationRequestTest {
             assertTrue(exception.cause is KeyException)
         }
 
-        @Nested
-        inner class CRACountersignature {
-            @Test
-            fun `Malformed values should be refused`() {
-                val serialization = ASN1Utils.serializeSequence(
-                    arrayOf(
-                        DEROctetString(keyPair.public.encoded),
-                        DEROctetString("not a SignedData value".toByteArray())
-                    ),
-                    false
-                )
+        @Test
+        fun `Invalid CRA countersignatures should be refused`() {
+            val serialization = ASN1Utils.serializeSequence(
+                arrayOf(
+                    DEROctetString(keyPair.public.encoded),
+                    DEROctetString(craSerialized),
+                    DEROctetString(RSASigning.sign("foo".toByteArray(), keyPair.private))
+                ),
+                false
+            )
 
-                val exception = assertThrows<InvalidMessageException> {
-                    ClientRegistrationRequest.deserialize(serialization)
-                }
-
-                assertEquals(
-                    "CRA countersignature is not a valid SignedData value",
-                    exception.message
-                )
-                assertTrue(exception.cause is SignedDataException)
+            val exception = assertThrows<InvalidMessageException> {
+                ClientRegistrationRequest.deserialize(serialization)
             }
 
-            @Test
-            fun `Encapsulated public key should correspond to countersignature private key`() {
-                val anotherKeyPair = generateRSAKeyPair()
-                val invalidCRASerialized =
-                    SignedData.sign("f".toByteArray(), anotherKeyPair.private).serialize()
-                val serialization = ASN1Utils.serializeSequence(
-                    arrayOf(
-                        DEROctetString(keyPair.public.encoded),
-                        DEROctetString(invalidCRASerialized)
-                    ),
-                    false
-                )
+            assertEquals("CRA countersignature is invalid", exception.message)
+        }
 
-                val exception = assertThrows<InvalidMessageException> {
-                    ClientRegistrationRequest.deserialize(serialization)
-                }
+        @Test
+        fun `Valid values should be accepted`() {
+            val crr = ClientRegistrationRequest(keyPair.public, craSerialized)
+            val serialization = crr.serialize(keyPair.private)
 
-                assertEquals(
-                    "CRA countersignature is not a valid SignedData value",
-                    exception.message
-                )
-                assertTrue(exception.cause is SignedDataException)
-            }
+            val crrDeserialized = ClientRegistrationRequest.deserialize(serialization)
 
-            @Test
-            fun `Plaintext should be a DER sequence`() {
-                val invalidCRACountersignature =
-                    SignedData.sign(DERNull.INSTANCE.encoded, keyPair.private)
-                val serialization = ASN1Utils.serializeSequence(
-                    arrayOf(
-                        DEROctetString(keyPair.public.encoded),
-                        DEROctetString(invalidCRACountersignature.serialize())
-                    ),
-                    false
-                )
-
-                val exception = assertThrows<InvalidMessageException> {
-                    ClientRegistrationRequest.deserialize(serialization)
-                }
-
-                assertEquals(
-                    "CRA countersignature plaintext should be a DER sequence",
-                    exception.message
-                )
-                assertTrue(exception.cause is ASN1Exception)
-            }
-
-            @Test
-            fun `Sequence should have at least 2 items`() {
-                val invalidCRACountersignaturePlaintext =
-                    ASN1Utils.serializeSequence(arrayOf(DERNull.INSTANCE), false)
-                val invalidCRACountersignature =
-                    SignedData.sign(invalidCRACountersignaturePlaintext, keyPair.private)
-                val serialization = ASN1Utils.serializeSequence(
-                    arrayOf(
-                        DEROctetString(keyPair.public.encoded),
-                        DEROctetString(invalidCRACountersignature.serialize())
-                    ),
-                    false
-                )
-
-                val exception = assertThrows<InvalidMessageException> {
-                    ClientRegistrationRequest.deserialize(serialization)
-                }
-
-                assertEquals(
-                    "CRA countersignature sequence should have at least 2 items (got 1)",
-                    exception.message
-                )
-            }
-
-            @Test
-            fun `Invalid OIDs should be refused`() {
-                val invalidOID = ASN1ObjectIdentifier("1.2.3")
-                val invalidCRACountersignaturePlaintext = ASN1Utils.serializeSequence(
-                    arrayOf(invalidOID, DERNull.INSTANCE, DERNull.INSTANCE),
-                    false
-                )
-                val invalidCRACountersignature =
-                    SignedData.sign(invalidCRACountersignaturePlaintext, keyPair.private)
-                val serialization = ASN1Utils.serializeSequence(
-                    arrayOf(
-                        DEROctetString(keyPair.public.encoded),
-                        DEROctetString(invalidCRACountersignature.serialize())
-                    ),
-                    false
-                )
-
-                val exception = assertThrows<InvalidMessageException> {
-                    ClientRegistrationRequest.deserialize(serialization)
-                }
-
-                assertEquals(
-                    "CRA countersignature has invalid OID (got ${invalidOID.id})",
-                    exception.message
-                )
-            }
-
-            @Test
-            fun `Valid values should be accepted`() {
-                val crr = ClientRegistrationRequest(keyPair.public, craSerialized)
-                val serialization = crr.serialize(keyPair.private)
-
-                val crrDeserialized = ClientRegistrationRequest.deserialize(serialization)
-
-                assertEquals(
-                    crr.clientPublicKey.encoded.asList(),
-                    crrDeserialized.clientPublicKey.encoded.asList()
-                )
-                assertEquals(crr.craSerialized.asList(), crrDeserialized.craSerialized.asList())
-            }
+            assertEquals(
+                crr.clientPublicKey.encoded.asList(),
+                crrDeserialized.clientPublicKey.encoded.asList()
+            )
+            assertEquals(crr.craSerialized.asList(), crrDeserialized.craSerialized.asList())
         }
     }
 }


### PR DESCRIPTION
Doing this now because PKI.js won't support it.