### PR TITLE
fix(RAMF): Check that sender is trusted even when recipient is public

### DIFF
--- a/src/main/kotlin/tech/relaycorp/relaynet/ramf/RAMFMessage.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/ramf/RAMFMessage.kt
@@ -11,7 +11,7 @@ import java.security.PrivateKey
 import java.time.ZoneId
 import java.time.ZoneOffset.UTC
 import java.time.ZonedDateTime
-import java.util.*
+import java.util.UUID
 
 private const val MAX_RECIPIENT_ADDRESS_LENGTH = 1024
 private const val MAX_MESSAGE_ID_LENGTH = 64

--- a/src/main/kotlin/tech/relaycorp/relaynet/ramf/RAMFMessage.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/ramf/RAMFMessage.kt
@@ -11,7 +11,7 @@ import java.security.PrivateKey
 import java.time.ZoneId
 import java.time.ZoneOffset.UTC
 import java.time.ZonedDateTime
-import java.util.UUID
+import java.util.*
 
 private const val MAX_RECIPIENT_ADDRESS_LENGTH = 1024
 private const val MAX_MESSAGE_ID_LENGTH = 64
@@ -21,7 +21,7 @@ private const val DEFAULT_TTL_MINUTES = 5
 private const val DEFAULT_TTL_SECONDS = DEFAULT_TTL_MINUTES * 60
 
 internal typealias RAMFMessageConstructor<M> =
-        (String, ByteArray, Certificate, String?, ZonedDateTime?, Int?, Set<Certificate>?) -> M
+    (String, ByteArray, Certificate, String?, ZonedDateTime?, Int?, Set<Certificate>?) -> M
 
 private val PRIVATE_ADDRESS_REGEX = "^0[a-f0-9]+$".toRegex()
 
@@ -120,10 +120,12 @@ abstract class RAMFMessage<P : Payload> internal constructor(
     /**
      * Validate the message.
      *
-     * If the recipient address is private, passing a collection of `trustedCAs` will also make
-     * sure that the sender is authorized to send this message to the recipient.
+     * Passing a collection of [trustedCAs] will also verify:
      *
-     * If there are no trusted CAs, avoid setting `trustedCAs` to an empty collection as that will
+     * - That there's a valid path between the sender's certificate and one of the [trustedCAs].
+     * - That, if the recipient address is private, the sender's issuer is the recipient itself.
+     *
+     * If there are no trusted CAs, avoid setting [trustedCAs] to an empty collection as that will
      * always cause validation to fail. This is intentional: We won't try to guess whether you made
      * a mistake or really meant to skip authorization checks.
      *
@@ -147,8 +149,8 @@ abstract class RAMFMessage<P : Payload> internal constructor(
             throw RAMFException("Invalid sender certificate", exc)
         }
 
-        if (trustedCAs != null && isRecipientAddressPrivate) {
-            validateAuthorization(trustedCAs)
+        if (trustedCAs != null) {
+            validateAuthorization(trustedCAs, isRecipientAddressPrivate)
         }
     }
 
@@ -191,17 +193,22 @@ abstract class RAMFMessage<P : Payload> internal constructor(
     }
 
     @Throws(InvalidMessageException::class)
-    private fun validateAuthorization(trustedCAs: Collection<Certificate>) {
+    private fun validateAuthorization(
+        trustedCAs: Collection<Certificate>,
+        isRecipientAddressPrivate: Boolean
+    ) {
         val certificationPath = try {
             getSenderCertificationPath(trustedCAs)
         } catch (exc: CertificateException) {
-            throw InvalidMessageException("Sender is not authorized", exc)
+            throw InvalidMessageException("Sender is not trusted", exc)
         }
 
-        val recipientCertificate = certificationPath[1]
-        val recipientPrivateAddress = recipientCertificate.subjectPrivateAddress
-        if (recipientPrivateAddress != recipientAddress) {
-            throw InvalidMessageException("Sender is authorized by the wrong recipient")
+        if (isRecipientAddressPrivate) {
+            val recipientCertificate = certificationPath[1]
+            val recipientPrivateAddress = recipientCertificate.subjectPrivateAddress
+            if (recipientPrivateAddress != recipientAddress) {
+                throw InvalidMessageException("Sender is authorized by the wrong recipient")
+            }
         }
     }
 

--- a/src/test/kotlin/tech/relaycorp/relaynet/ramf/RAMFMessageTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/ramf/RAMFMessageTest.kt
@@ -14,7 +14,7 @@ import tech.relaycorp.relaynet.wrappers.x509.Certificate
 import tech.relaycorp.relaynet.wrappers.x509.CertificateException
 import java.time.ZoneId
 import java.time.ZonedDateTime
-import java.util.*
+import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -634,7 +634,7 @@ class RAMFMessageTest {
             }
 
             @Test
-            fun `Message should be refused if recipient is private and doesn't match sender issuer`() {
+            fun `Message should be refused if private recipient doesn't match sender issuer`() {
                 val anotherRecipientKeyPair = generateRSAKeyPair()
                 val anotherRecipientCert = issueStubCertificate(
                     anotherRecipientKeyPair.public,

--- a/src/test/kotlin/tech/relaycorp/relaynet/ramf/RAMFMessageTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/ramf/RAMFMessageTest.kt
@@ -14,7 +14,7 @@ import tech.relaycorp.relaynet.wrappers.x509.Certificate
 import tech.relaycorp.relaynet.wrappers.x509.CertificateException
 import java.time.ZoneId
 import java.time.ZonedDateTime
-import java.util.UUID
+import java.util.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -599,12 +599,12 @@ class RAMFMessageTest {
                     message.validate(null, setOf(FullCertPath.PUBLIC_GW))
                 }
 
-                assertEquals("Sender is not authorized", exception.message)
+                assertEquals("Sender is not trusted", exception.message)
                 assertTrue(exception.cause is CertificateException)
             }
 
             @Test
-            fun `Message should be accepted if sender is trusted`() {
+            fun `Message should be accepted if recipient is private and sender is trusted`() {
                 val message = StubEncryptedRAMFMessage(
                     FullCertPath.PRIVATE_ENDPOINT.subjectPrivateAddress,
                     payload,
@@ -619,7 +619,22 @@ class RAMFMessageTest {
             }
 
             @Test
-            fun `Message should be refused if message recipient does not match sender issuer`() {
+            fun `Message should be accepted if recipient is public and sender is trusted`() {
+                val message = StubEncryptedRAMFMessage(
+                    "https://endpoint.example.com",
+                    payload,
+                    FullCertPath.PDA,
+                    senderCertificateChain = setOf(
+                        FullCertPath.PRIVATE_GW,
+                        FullCertPath.PRIVATE_ENDPOINT
+                    )
+                )
+
+                message.validate(null, setOf(FullCertPath.PUBLIC_GW))
+            }
+
+            @Test
+            fun `Message should be refused if recipient is private and doesn't match sender issuer`() {
                 val anotherRecipientKeyPair = generateRSAKeyPair()
                 val anotherRecipientCert = issueStubCertificate(
                     anotherRecipientKeyPair.public,
@@ -637,22 +652,6 @@ class RAMFMessageTest {
                 }
 
                 assertEquals("Sender is authorized by the wrong recipient", exception.message)
-            }
-
-            @Test
-            fun `Authorization enforcement should be skipped if recipient address is public`() {
-                val untrustedSenderKeyPair = generateRSAKeyPair()
-                val untrustedSenderCert = issueStubCertificate(
-                    untrustedSenderKeyPair.public,
-                    untrustedSenderKeyPair.private
-                )
-                val message = StubEncryptedRAMFMessage(
-                    "https://foo.relaycorp.tech",
-                    payload,
-                    untrustedSenderCert
-                )
-
-                message.validate(null, setOf(FullCertPath.PUBLIC_GW))
             }
 
             @Test


### PR DESCRIPTION
Needed for https://github.com/relaycorp/relaynet-gateway-android/pull/122